### PR TITLE
fix: contain export card scaling within frame

### DIFF
--- a/match-attax-generator/src/app/page.tsx
+++ b/match-attax-generator/src/app/page.tsx
@@ -613,9 +613,9 @@ export default function Home() {
       const resolvedLogoImage =
         logoImageElement ?? (logoImage ? await loadImage(logoImage) : null);
 
-      // Render the card to COVER the 1080x1350 frame (fill width, crop height)
+      // Render the card to CONTAIN within the 1080x1350 frame (preserve full height)
       const cardCanvas = document.createElement("canvas");
-      const scaleToCover = Math.max(
+      const scaleToCover = Math.min(
         wrapperWidth / CARD_WIDTH,
         wrapperHeight / CARD_HEIGHT,
       );
@@ -648,7 +648,7 @@ export default function Home() {
       wctx.fillStyle = backgroundGradient;
       wctx.fillRect(0, 0, wrapperWidth, wrapperHeight);
 
-      // Center the card; canvas will crop overflow
+      // Center the contained card; equal offsets keep it aligned within the frame
       const offsetX = Math.round((wrapperWidth - cardCanvas.width) / 2);
       const offsetY = Math.round((wrapperHeight - cardCanvas.height) / 2);
       wctx.drawImage(cardCanvas, offsetX, offsetY);

--- a/match-attax-generator/src/app/page.tsx
+++ b/match-attax-generator/src/app/page.tsx
@@ -603,8 +603,9 @@ export default function Home() {
     setIsDownloading(true);
     try {
       const wrapperCanvas = document.createElement("canvas");
-      const wrapperWidth = 1080;
       const wrapperHeight = 1350;
+      const exportScale = wrapperHeight / CARD_HEIGHT;
+      const wrapperWidth = Math.round(CARD_WIDTH * exportScale);
       wrapperCanvas.width = wrapperWidth;
       wrapperCanvas.height = wrapperHeight;
 
@@ -613,15 +614,12 @@ export default function Home() {
       const resolvedLogoImage =
         logoImageElement ?? (logoImage ? await loadImage(logoImage) : null);
 
-      // Render the card to CONTAIN within the 1080x1350 frame (preserve full height)
+      // Render the card scaled to the export height so the full design remains visible
       const cardCanvas = document.createElement("canvas");
-      const scaleToCover = Math.min(
-        wrapperWidth / CARD_WIDTH,
-        wrapperHeight / CARD_HEIGHT,
-      );
+      const scaleToContain = exportScale;
       await drawCard({
         canvas: cardCanvas,
-        scale: scaleToCover,
+        scale: scaleToContain,
         playerImage: resolvedPlayerImage,
         logoImage: resolvedLogoImage,
         data: {
@@ -639,7 +637,7 @@ export default function Home() {
       const wctx = wrapperCanvas.getContext("2d");
       if (!wctx) throw new Error("Failed to get 2D context for export");
 
-      // Background fill/gradient to 4:5 frame
+      // Background fill/gradient to match the resized export canvas
       wctx.fillStyle = "#020617";
       wctx.fillRect(0, 0, wrapperWidth, wrapperHeight);
       const backgroundGradient = wctx.createLinearGradient(0, 0, wrapperWidth, wrapperHeight);
@@ -648,10 +646,8 @@ export default function Home() {
       wctx.fillStyle = backgroundGradient;
       wctx.fillRect(0, 0, wrapperWidth, wrapperHeight);
 
-      // Center the contained card; equal offsets keep it aligned within the frame
-      const offsetX = Math.round((wrapperWidth - cardCanvas.width) / 2);
-      const offsetY = Math.round((wrapperHeight - cardCanvas.height) / 2);
-      wctx.drawImage(cardCanvas, offsetX, offsetY);
+      // Draw the card flush to the edges – no horizontal or vertical letterboxing
+      wctx.drawImage(cardCanvas, 0, 0);
 
       const dataUrl = wrapperCanvas.toDataURL("image/png");
       const link = document.createElement("a");


### PR DESCRIPTION
## Summary
- switch the export canvas scaling to contain the card within the 1080x1350 frame
- clarify the centering comment to reflect the new contained offsets

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: unable to fetch Google Fonts in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e28cdd27b88333a7f89d6f28114bff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exported card images now scale to fit the export frame using contain scaling, preserving the entire design without cropping.
  * Background gradient generation now adapts when a player image is present for more accurate visuals.
* **Bug Fixes**
  * Exports are rendered edge-to-edge (no centering or letterboxing), avoiding unwanted clipping or overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->